### PR TITLE
AGENTS.md, HISTORY, ConsoleBudgeter textfacit och plansync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Instruktioner för agenter (Cursor m.fl.)
+
+Det här dokumentet är **bindande** för automatiserad hjälp i repot. Läs det innan du ändrar kod, grenar eller facit.
+
+## 1. Verifiera *den här* arbetskopian — inte “någon branch”
+
+- Kör `git branch --show-current`, `git log -5 --oneline` och vid behov `git merge-base master HEAD` **innan** du påstår vad som finns i repot eller “saknas”.
+- Gissa inte bort facit-filer, `ConsoleBudgeter` eller andra artefakter: lista dem med verktyg eller `git ls-files`.
+- Om användaren säger att något ska ligga i “senaste branchen”: tolka det som **den gren du faktiskt står på** tills de anger annat.
+
+## 2. Grenar och “all kod i senaste branchen”
+
+- Nya funktionsgrenar ska följa projektets namnkonvention (t.ex. `cursor/...-d200` i denna miljö).
+- Om du fortsätter på en befintlig `cursor/…`-gren utan att först merga `master` in i den, blir PR-diffen ofta en **kedja** av tidigare arbete. Det är ett medvetet val; om målet är en **minimal PR** mot `master`, checkout från uppdaterad `master` (eller rebase) enligt vad användaren vill.
+- **Implementera inte** funktioner genom att anta att de redan finns i en annan remote-gren om de inte syns i den checkout du jobbar i.
+
+## 3. Textfacit = kör konsolappen, spara stdout — ingen parallell pipeline
+
+- **Textfacit** är den fulla rapporten som **`ConsoleBudgeter`** skriver till fil (UTF-8), inte en separat Python-beräkning och inte manuellt hopkok som duplicerar affärslogik.
+- Standardkommando (från repo-roten, när `pelles budget.xls` och kategorier finns där `ConsoleBudgeter/Data/GeneralSettings.xml` pekar):
+
+```bash
+dotnet run --project ConsoleBudgeter/ConsoleBudgeter.csproj -- --year 2014 --year 2015 --out Facit/facit-2014-2015-console.txt
+```
+
+- Vid behov, peka ut en annan `.xls` än standard i `ConsoleBudgeter/Data/GeneralSettings.xml`:
+  `--transaction-file /full/path/till/pelles budget.xls`
+- Rapporten inleds med en **diagnostikrad** (antal transaktioner per år). Om 2014/2015 blir 0: fel källa eller ofullständig fil — byt fil, committa inte en tom “facit”.
+
+- Filnamn kan vara t.ex. `Facit/facit-2014-2015-console.txt` (byt bara om teamet enas om annat namn).
+- **Ändra inte** en committad facit-fil för att “få gröna tester”. Uppdatera facit endast när källan (Excel/regler) eller rapportpipen medvetet ändrats; granska diff.
+
+## 4. Efter genomförd och verifierad ändring: plan, todo, README, historik
+
+- Uppdatera `plan.md` / `todo.md` / `README.md` så de stämmer med **faktisk kod** (inga kvarvarande påståenden om att `TransactionHandler` “saknas” om klassen finns).
+- Lägg en kort post i **`HISTORY.md`** (vad, varför, vilka filer) vid varje väsentlig åtgärd som användaren bör kunna spåra.
+
+## 5. `TransactionHandler`
+
+- Klassen ligger i `WebBankBudgeterService/TransactionHandler.cs`. Planens gamla formuleringar om att den “saknas fysiskt” ska **rättas i planen**, inte upprepas i nya svar.
+
+## 6. Linux / headless
+
+- `WebBankBudgeterUi` kräver `net8.0-windows`. Konsol- och serviceprojekt kan byggas på Linux när .NET SDK finns.
+- I denna miljö kan `dotnet` saknas i PATH; då ska agenten **dokumentera** att bygget inte körts här och ange exakt kommando för användaren — men ändå leverera konsekvent kod.

--- a/Budgetterarn.sln
+++ b/Budgetterarn.sln
@@ -57,6 +57,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Utilities", "Utilities\Util
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebBankBudgeterUiTest", "WebBankBudgeterUiTest\WebBankBudgeterUiTest.csproj", "{0ADD4DD2-4790-4729-9F26-B44943DAD3D1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleBudgeter", "ConsoleBudgeter\ConsoleBudgeter.csproj", "{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -451,6 +453,26 @@ Global
 		{0ADD4DD2-4790-4729-9F26-B44943DAD3D1}.Release|x64.Build.0 = Release|Any CPU
 		{0ADD4DD2-4790-4729-9F26-B44943DAD3D1}.Release|x86.ActiveCfg = Release|Any CPU
 		{0ADD4DD2-4790-4729-9F26-B44943DAD3D1}.Release|x86.Build.0 = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|Win32.Build.0 = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|Win32.ActiveCfg = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|Win32.Build.0 = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|x64.Build.0 = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -476,6 +498,7 @@ Global
 		{6AAAADFC-AC1C-4EB9-9BB6-11D8BE6FFD69} = {181DDD13-5842-4AEF-B89F-B2F4F4861346}
 		{0E238DA8-D393-4502-A90B-E4E3BF744F12} = {9C9A93BC-FC73-4C77-B0D3-62B3B7F2B8AF}
 		{0ADD4DD2-4790-4729-9F26-B44943DAD3D1} = {FE738935-FFAA-4B40-A051-A6F9B8D58964}
+		{C4B8F2E1-9A3D-4C7B-8E5F-1A2B3C4D5E6F} = {9C9A93BC-FC73-4C77-B0D3-62B3B7F2B8AF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1E1C4CD8-26A7-4A10-804E-67B76E8DBCF8}

--- a/ConsoleBudgeter/ConsoleBudgeter.csproj
+++ b/ConsoleBudgeter/ConsoleBudgeter.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>ConsoleBudgeter</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GeneralSettingsHandler\GeneralSettingsHandler.csproj" />
+    <ProjectReference Include="..\InbudgetHandler\InbudgetHandler.csproj" />
+    <ProjectReference Include="..\WebBankBudgeterService\WebBankBudgeterService.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Data\GeneralSettings.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestData\BudgetIns.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/ConsoleBudgeter/Data/GeneralSettings.xml
+++ b/ConsoleBudgeter/Data/GeneralSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<GeneralSettings>
+  <!-- Relativa till ConsoleBudgeter/bin/Debug/net8.0/ (eller motsvarande output) -->
+  <Property Name="TransactionTestFilePath" Value="../../../../pelles budget.xls"/>
+  <Property Name="CategoryPath" Value="../../../../BudgetterarnUi/Data/Categories.xml"/>
+</GeneralSettings>

--- a/ConsoleBudgeter/Program.cs
+++ b/ConsoleBudgeter/Program.cs
@@ -1,0 +1,342 @@
+using System.Globalization;
+using System.Text;
+using BudgeterCore.Entities;
+using GeneralSettingsHandler;
+using InbudgetHandler;
+using InbudgetHandler.Model;
+using WebBankBudgeterService;
+using WebBankBudgeterService.Model;
+using WebBankBudgeterService.Model.ViewModel;
+using WebBankBudgeterService.MonthAvarages;
+using WebBankBudgeterService.Services;
+
+namespace ConsoleBudgeter;
+
+internal static class Program
+{
+    private static readonly CultureInfo SvSe = CultureInfo.GetCultureInfo("sv-SE");
+
+    private static async Task<int> Main(string[] args)
+    {
+        var years = new List<int>();
+        string? outPath = null;
+        string? transactionFileOverride = null;
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (string.Equals(args[i], "--year", StringComparison.OrdinalIgnoreCase)
+                && i + 1 < args.Length
+                && int.TryParse(args[++i], out var y))
+            {
+                years.Add(y);
+            }
+            else if (string.Equals(args[i], "--out", StringComparison.OrdinalIgnoreCase)
+                     && i + 1 < args.Length)
+            {
+                outPath = args[++i];
+            }
+            else if (string.Equals(args[i], "--transaction-file", StringComparison.OrdinalIgnoreCase)
+                     && i + 1 < args.Length)
+            {
+                transactionFileOverride = args[++i];
+            }
+        }
+
+        if (years.Count == 0)
+        {
+            years.Add(2014);
+            years.Add(2015);
+        }
+
+        var sb = new StringBuilder();
+        void W(string s) => sb.AppendLine(s);
+
+        var appDir = AppContext.BaseDirectory;
+        var settingsPath = Path.Combine(appDir, "Data", "GeneralSettings.xml");
+        if (!File.Exists(settingsPath))
+        {
+            Console.Error.WriteLine("Saknar Data/GeneralSettings.xml i output. Bygg projektet så att filen kopieras.");
+            return 1;
+        }
+
+        var getter = new GeneralSettingsGetter(settingsPath);
+        var transactionPath = getter.GetStringSetting("TransactionTestFilePath");
+        var categoryRelative = getter.GetStringSetting("CategoryPath");
+        if (string.IsNullOrWhiteSpace(transactionPath) || string.IsNullOrWhiteSpace(categoryRelative))
+        {
+            Console.Error.WriteLine("GeneralSettings.xml saknar TransactionTestFilePath eller CategoryPath.");
+            return 1;
+        }
+
+        var categoryPath = Path.GetFullPath(Path.Combine(appDir, categoryRelative));
+        var resolvedTransactionPath = string.IsNullOrWhiteSpace(transactionFileOverride)
+            ? Path.GetFullPath(Path.Combine(appDir, transactionPath))
+            : Path.GetFullPath(transactionFileOverride);
+        if (!File.Exists(resolvedTransactionPath))
+        {
+            Console.Error.WriteLine("Transaktionsfil finns inte: " + resolvedTransactionPath);
+            Console.Error.WriteLine(
+                "Ange sökväg i ConsoleBudgeter/Data/GeneralSettings.xml eller flaggan --transaction-file.");
+            return 1;
+        }
+
+        if (!File.Exists(categoryPath))
+        {
+            Console.Error.WriteLine("Kategorifil finns inte: " + categoryPath);
+            return 1;
+        }
+
+        var inBudgetPath = Path.Combine(appDir, "TestData", "BudgetIns.json");
+        if (!File.Exists(inBudgetPath))
+        {
+            Console.Error.WriteLine("Saknar TestData/BudgetIns.json i output.");
+            return 1;
+        }
+
+        var noop = static (string _) => { };
+        var tableGetter = new TableGetter { AddAverageColumn = true };
+        var transactionHandler = new TransactionHandler(
+            noop,
+            tableGetter,
+            categoryPath,
+            resolvedTransactionPath);
+
+        var inBudgetHandler = new InBudgetHandler(inBudgetPath);
+
+        if (!await transactionHandler.GetTransactionsAsync())
+        {
+            Console.Error.WriteLine("Kunde inte läsa transaktioner.");
+            return 1;
+        }
+
+        transactionHandler.SortTransactions();
+        transactionHandler.RemoveDuplicates();
+
+        var allTransactionsBackup = new TransactionList
+        {
+            Transactions = transactionHandler.TransactionList!.Transactions.ToList(),
+            Account = transactionHandler.TransactionList.Account
+        };
+
+        var countsByYear = allTransactionsBackup.Transactions
+            .GroupBy(t => t.DateAsDate.Year)
+            .OrderBy(g => g.Key)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        W("## Diagnostik");
+        W("Transaktionsfil: " + resolvedTransactionPath);
+        W("Antal transaktioner efter inläsning: " + allTransactionsBackup.Transactions.Count);
+        W("Antal per kalenderår: " + string.Join(
+            ", ",
+            countsByYear.Select(kv => $"{kv.Key}={kv.Value}")));
+        if (years.Any(y => !countsByYear.ContainsKey(y) || countsByYear[y] == 0))
+        {
+            W("Varning: minst ett begärt år saknar transaktioner i denna fil.");
+            W("Byt källa med --transaction-file eller uppdatera GeneralSettings.xml.");
+        }
+
+        foreach (var year in years.OrderBy(y => y))
+        {
+            W("");
+            W(new string('=', 72));
+            W($" År {year} ");
+            W(new string('=', 72));
+
+            transactionHandler.SetTransactionList(new TransactionList
+            {
+                Transactions = allTransactionsBackup.Transactions.ToList(),
+                Account = allTransactionsBackup.Account
+            });
+            var filtered = TransFilterer.FilterTransactions(transactionHandler.TransactionList!, year);
+            transactionHandler.SetTransactionList(filtered);
+
+            var table = transactionHandler.GetTextTableFromTransactions();
+            if (table?.BudgetRows == null)
+            {
+                W("(ingen tabelldata)");
+                continue;
+            }
+
+            table.AveragesForTransactions = SkapaInPosterHanterare.GetAvarages(
+                filtered,
+                new DateTime(year, 1, 1));
+
+            W("## Inkomster / in-budget (gv_incomes) — rådata från BudgetIns.json");
+            inBudgetHandler.SetInPosterFilter(
+                new DateTime(year, 1, 1),
+                new DateTime(year, 12, 31));
+            var inPoster = await inBudgetHandler.GetInPoster();
+            inPoster = inPoster
+                .Where(i => i.YearAndMonth.Year == year)
+                .OrderBy(i => i.YearAndMonth)
+                .ToList();
+            var inRubriker = HämtaInKolumnRubriker(inPoster)
+                .OrderBy(Transaction.GetDateFromYearMonthName)
+                .ToList();
+            var inRader = await inBudgetHandler.HämtaRaderFörUiBindningAsync();
+            AppendIncomeSection(W, inRubriker, inRader);
+
+            W("");
+            W("## Utgifter (strukturerad tabell som gv_budget)");
+            AppendStructuredBudgetTable(W, table);
+
+            var utgifterFörKvar = GetExpenseBudgetRowsForKvar(table);
+            W("");
+            W("## Kvar (gv_Kvar) — IN + UT per kategori (döljer kategori \"-\")");
+            var inFörKvar = inRader
+                .Where(r => !string.Equals(r.RadNamnY?.Trim(), InBudgetHandler.SummaText, StringComparison.Ordinal))
+                .Where(r => !string.Equals(r.RadNamnY?.Trim(), "-", StringComparison.Ordinal))
+                .ToList();
+            var kvarRader = InBudgetKvarCalculator.SnurraIgenom(inFörKvar, utgifterFörKvar, msg => W(msg));
+            AppendIncomeStyleTable(W, inRubriker, kvarRader, skipCategoryDash: true);
+
+            W("");
+            W("## Totals (gv_Totals)");
+            var averages = new MonthAvaragesCalcs(filtered).GetMonthAvarages();
+            W($"Återkommande snitt\t{averages.ReccuringCosts.ToString("# ##0", CultureInfo.InvariantCulture)}");
+            W($"Inkomster snitt\t{averages.Incomes.ToString("# ##0", CultureInfo.InvariantCulture)}");
+            W($"Diff snitt\t{averages.IncomeDiffCosts.ToString("# ##0", CultureInfo.InvariantCulture)}");
+
+            W("");
+            W("## Transaktioner (alla rader för året)");
+            foreach (var t in filtered.Transactions.OrderBy(t => t.DateAsDate))
+            {
+                W($"{t.DateAsDate:yyyy-MM-dd}\t{t.AmountAsDouble}\t{t.Description}\t{t.CategoryName}");
+            }
+        }
+
+        var text = sb.ToString();
+        if (!string.IsNullOrEmpty(outPath))
+        {
+            var fullOut = Path.GetFullPath(outPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(fullOut)!);
+            await File.WriteAllTextAsync(fullOut, text, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            Console.WriteLine("Skrev: " + fullOut);
+        }
+        else
+        {
+            Console.Write(text);
+        }
+
+        return 0;
+    }
+
+    private static List<string> HämtaInKolumnRubriker(List<InBudget> inPoster)
+    {
+        var keys = new List<string>();
+        foreach (var p in inPoster.OrderBy(x => x.YearAndMonth))
+        {
+            var key = Transaction.GetYearMonthName(p.YearAndMonth);
+            if (!keys.Contains(key))
+            {
+                keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+
+    private static void AppendIncomeSection(
+        Action<string> w,
+        List<string> månadsRubriker,
+        List<Rad> rader)
+    {
+        foreach (var rad in rader)
+        {
+            if (string.Equals(rad.RadNamnY?.Trim(), InBudgetHandler.SummaText, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var cells = new List<string> { rad.RadNamnY ?? "" };
+            foreach (var h in månadsRubriker.OrderBy(Transaction.GetDateFromYearMonthName))
+            {
+                rad.Kolumner.TryGetValue(h, out var v);
+                cells.Add(v.ToString("# ##0", CultureInfo.InvariantCulture));
+            }
+
+            w(string.Join("\t", cells));
+        }
+    }
+
+    private static void AppendIncomeStyleTable(
+        Action<string> w,
+        List<string> månadsRubriker,
+        List<Rad> rader,
+        bool skipCategoryDash)
+    {
+        foreach (var rad in rader)
+        {
+            if (skipCategoryDash && string.Equals(rad.RadNamnY?.Trim(), "-", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var cells = new List<string> { rad.RadNamnY ?? "" };
+            foreach (var h in månadsRubriker.OrderBy(Transaction.GetDateFromYearMonthName))
+            {
+                rad.Kolumner.TryGetValue(h, out var v);
+                cells.Add(v.ToString("# ##0", CultureInfo.InvariantCulture));
+            }
+
+            w(string.Join("\t", cells));
+        }
+    }
+
+    private static void AppendStructuredBudgetTable(Action<string> w, TextToTableOutPuter table)
+    {
+        var builder = new BudgetStructureBuilder();
+        var structured = builder.BuildStructuredBudget(table.BudgetRows, table.ColumnHeaders);
+        var monthCols = table.ColumnHeaders
+            .Where(h => !h.Contains("Category", StringComparison.OrdinalIgnoreCase)
+                        && !h.Contains("Average", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        w(string.Join("\t", new[] { "Kategori" }.Concat(monthCols).Concat(new[] { "Summa" })));
+
+        foreach (var row in structured.Rows)
+        {
+            var cells = new List<string> { row.CategoryText ?? "" };
+            double rowTotal = 0;
+            foreach (var col in monthCols)
+            {
+                row.AmountsForMonth.TryGetValue(col, out var v);
+                rowTotal += v;
+                cells.Add(v.ToString("N0", SvSe));
+            }
+
+            cells.Add(rowTotal.ToString("N0", SvSe));
+            w(string.Join("\t", cells));
+        }
+    }
+
+    /// <summary>
+    /// Utgiftsrader som i UI-tabellen före första summering / tomrad (samma ordning som strukturbyggaren).
+    /// </summary>
+    private static List<BudgetRow> GetExpenseBudgetRowsForKvar(TextToTableOutPuter table)
+    {
+        var builder = new BudgetStructureBuilder();
+        var structured = builder.BuildStructuredBudget(table.BudgetRows, table.ColumnHeaders);
+        var list = new List<BudgetRow>();
+        foreach (var row in structured.Rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.CategoryText))
+            {
+                break;
+            }
+
+            if (row.CategoryText.Contains("===", StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            if (string.Equals(row.CategoryText.Trim(), "-", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            list.Add(row);
+        }
+
+        return list;
+    }
+}

--- a/ConsoleBudgeter/TestData/BudgetIns.json
+++ b/ConsoleBudgeter/TestData/BudgetIns.json
@@ -1,0 +1,22 @@
+[
+  {
+    "CategoryDescription": "el",
+    "BudgetValue": 1100,
+    "YearAndMonth": "2016-05-01T00:00:00"
+  },
+  {
+    "CategoryDescription": "hyra (inkl. 1k amortering)",
+    "BudgetValue": 2100,
+    "YearAndMonth": "2016-02-01T00:00:00"
+  },
+  {
+    "CategoryDescription": "el",
+    "BudgetValue": 1200,
+    "YearAndMonth": "2016-06-01T00:00:00"
+  },
+  {
+    "CategoryDescription": "hyra (inkl. 1k amortering)",
+    "BudgetValue": 2200,
+    "YearAndMonth": "2016-03-01T00:00:00"
+  }
+]

--- a/Facit/README.md
+++ b/Facit/README.md
@@ -1,0 +1,9 @@
+# Textfacit (konsol)
+
+Generera med:
+
+```bash
+dotnet run --project ConsoleBudgeter/ConsoleBudgeter.csproj -- --year 2014 --year 2015 --out Facit/facit-2014-2015-console.txt
+```
+
+Kontrollera att blocket **## Diagnostik** visar icke-noll transaktioner för 2014 och 2015 innan filen committas som facit. Vid 0 rader: använd `--transaction-file` mot rätt `.xls`-export.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,24 @@
+# Historik (webbankbudgeter)
+
+## A. Aktuellt — vad som gäller i denna arbetskopia
+
+### A.1 Gren `master` (2026-04-26)
+
+- **`git log -3 --oneline`:** `5e1c121` (facit-xlsx + plan/README), `90a5331` (plan + Kvar/Budget-bindning), `e125952` (UI-refactor).
+- **`git merge-base master HEAD`:** samma som `HEAD` när du står på `master` — det finns ingen lokal “kedja” av `cursor/…`-grenar i denna clone; tidigare Slack-sessioner kan ha jobbat i andra grenar på GitHub.
+
+### A.2 Denna commit (gren `cursor/agents-history-console-facit-d200`)
+
+- **`AGENTS.md`:** regler för agenter (facit via `ConsoleBudgeter`, ingen gissning om branches, uppdatering av plan/todo/README/HISTORY).
+- **`HISTORY.md`:** denna fil — fylls på vid väsentliga åtgärder.
+- **`ConsoleBudgeter`:** nytt `net8.0`-konsolprojekt i lösningen; skriver textfacit med `--out` och `--transaction-file` vid behov. Inställningar: `ConsoleBudgeter/Data/GeneralSettings.xml` (relativa sökvägar till `pelles budget.xls` och `BudgetterarnUi/Data/Categories.xml`). *Verifiering:* den incheckade `pelles budget.xls` i denna clone gav **0** transaktioner för 2014/2015 vid körning här — använd full export + diagnostikraderna i utskriften innan textfacit committas.
+- **`InbudgetHandler/InBudgetKvarCalculator.cs`:** `SnurraIgenom` flyttad hit så konsol och UI delar samma kvar-matematik; `WebBankBudgeter` delegerar dit.
+- **`BudgetStructureBuilder`:** inkomst = exakt trimmat `"+"`, förflyttning = exakt trimmat `" -"` (undviker felklassning av t.ex. `värnamoresor+övriga`).
+- **`plan.md` / `todo.md` / `README.md`:** städade mot faktisk kod (TransactionHandler finns; Kvar-läge dokumenterat).
+
+## B. Arkiv — äldre resonemang (behålls som bakgrund)
+
+- **`todo.md` (före 2026-04-26):** beskrev en fyra-stegs-plan där Kvar skulle vara en kopia av Budget Total. I koden finns i stället `BindKvarBudgetTableUi` som duplicerar budget-tabellen till `gv_Kvar`; separat `SnurraIgenom`-flöde finns men är inte kopplat i `FillTablesAsync` på samma sätt som i vissa Slack-versioner. Se aktuell `WebBankBudgeterUi.cs` för sanning.
+- Slack-tråden om flera `cursor/…`-PR:er i kedja gällde **andra clones**; jämför alltid med `git` i **din** arbetsyta.
+
+När Del A växer: flytta äldre punkter hit eller till `HISTORY_ARCHIVE.md`.

--- a/InbudgetHandler/InBudgetKvarCalculator.cs
+++ b/InbudgetHandler/InBudgetKvarCalculator.cs
@@ -1,0 +1,58 @@
+using InbudgetHandler.Model;
+using WebBankBudgeterService.Model;
+
+namespace InbudgetHandler;
+
+/// <summary>
+/// Kvar per kategori/månad: IN (budget) + UT (utfall; utgifter är negativa).
+/// Delad mellan WinForms och konsol — ingen referens till UI.
+/// </summary>
+public static class InBudgetKvarCalculator
+{
+    public static List<Rad> SnurraIgenom(
+        IEnumerable<Rad> inData,
+        List<BudgetRow> utgifter,
+        Action<string>? writeLine = null)
+    {
+        if (utgifter == null)
+        {
+            throw new ArgumentNullException(nameof(utgifter));
+        }
+
+        var kvarrader = new List<Rad>();
+        foreach (var inBudget in inData)
+        {
+            var motsvarandeUtgifterRader = utgifter
+                .Where(u => u.CategoryText.Trim() == inBudget.RadNamnY.Trim());
+
+            var nuvarandeRad = new Rad { RadNamnY = inBudget.RadNamnY };
+            foreach (var motsvarandeUtgiftsRad in motsvarandeUtgifterRader)
+            {
+                foreach (var utgiftsMånad in motsvarandeUtgiftsRad.AmountsForMonth)
+                {
+                    if (inBudget.Kolumner.ContainsKey(utgiftsMånad.Key))
+                    {
+                        var kvar = inBudget.Kolumner[utgiftsMånad.Key] + utgiftsMånad.Value;
+
+                        if (!nuvarandeRad.Kolumner.ContainsKey(utgiftsMånad.Key))
+                        {
+                            nuvarandeRad.Kolumner.Add(utgiftsMånad.Key, 0);
+                        }
+
+                        nuvarandeRad.Kolumner[utgiftsMånad.Key] += kvar;
+                    }
+                    else
+                    {
+                        var message = "Hittar ingen motsvarande inpost för utgift i :"
+                                      + utgiftsMånad.Key + " och kategori: " + inBudget.RadNamnY;
+                        writeLine?.Invoke(message);
+                    }
+                }
+            }
+
+            kvarrader.Add(nuvarandeRad);
+        }
+
+        return kvarrader;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Personligt budgetverktyg som läser banktransaktioner och visar dem i en kategoriserad budgetöversikt.
 
+## Dokumentation för agenter och spårbarhet
+
+- **[`AGENTS.md`](AGENTS.md)** — bindande regler för Cursor/agenter (facit via konsol, ingen gissning om branches, uppdatering av plan/todo).
+- **[`HISTORY.md`](HISTORY.md)** — kort logg över väsentliga ändringar i *den här* repoklonen.
+- **`plan.md` / `todo.md`** — ska hållas i synk med faktisk kod efter verifierad build (se `AGENTS.md`).
+
 ## Typ av projekt
 
 - **Plattform:** Windows Forms (.NET 8.0)
@@ -64,6 +70,7 @@ Budgetterarn.sln
 │
 ├── BudgetterarnUi/             # Äldre WinForms-UI (parallell/legacy)
 ├── BudgetterarnDAL/            # Äldre DAL med WebCrawlers
+├── ConsoleBudgeter/          # Konsol: textfacit / rapport (net8.0), `--out` för sparad utskrift
 │
 └── *Test-projekt:*
     ├── WebBankBudgeterServiceTest/
@@ -78,7 +85,7 @@ Budgetterarn.sln
 
 | Flik | DataGridView | Beskrivning |
 |------|-------------|-------------|
-| **Kvar** | `gv_Kvar` | Kvarvarande budget (budgeterat - faktisk utgift) |
+| **Kvar** | `gv_Kvar` | I nuvarande `FillTablesAsync`: samma tabellbindning som Budget Total (`BindKvarBudgetTableUi`). För IN+UT per rad finns `SnurraIgenom` + `VisaKvarRader_…` (se `todo.md`). |
 | **Incomes** | `gv_incomes` | Budgeterade inkomster per kategori och månad |
 | **Budget Total** | `gv_budget` | Alla utgifter/inkomster per kategori och månad med summor |
 | **Totals** | `gv_Totals` | Sammanfattande siffror (snitt, diff) |
@@ -107,7 +114,20 @@ UtgiftsHanterareUiBinder → gv_budget (Budget Total-fliken)
 
 - `WebBankBudgeterUi/Data/GeneralSettings.xml` — sökväg till transaktionsfil, kategorifil
 - `WebBankBudgeterUi/TestData/BudgetIns.json` — budgeterade belopp per kategori/månad
+- `ConsoleBudgeter/Data/GeneralSettings.xml` — relativa sökvägar till `pelles budget.xls` och `BudgetterarnUi/Data/Categories.xml` (för textfacit-körning)
 - `Pelles-budget-slim-2014-2015-gform.xlsx` (i repo-rot) — Excel-facit som `plan.md` refererar (kontoutdrag + budget 2014/2015)
+
+## Textfacit (konsol, 2014–2015)
+
+Kör samma pipeline som tjänstelagret och skriv full utskrift till fil (UTF-8). Skapa gärna mappen `Facit/` först.
+
+```bash
+dotnet run --project ConsoleBudgeter/ConsoleBudgeter.csproj -- --year 2014 --year 2015 --out Facit/facit-2014-2015-console.txt
+```
+
+Valfritt: `--transaction-file <sökväg>` om `pelles budget.xls` i repo-roten inte är samma export som innehåller alla år (konsolutskriften börjar med diagnostik: antal rader per år).
+
+Om `dotnet` saknas i miljön (t.ex. vissa sandlådor), kör samma kommando lokalt med .NET 8 SDK installerat.
 
 ## Teckenkodning
 

--- a/WebBankBudgeterService/Services/BudgetStructureBuilder.cs
+++ b/WebBankBudgeterService/Services/BudgetStructureBuilder.cs
@@ -21,12 +21,30 @@ namespace WebBankBudgeterService.Services
             var result = new StructuredBudgetTable();
             var rows = budgetRows.ToList();
 
-            // Separera kategorier
-            var incomeRows = rows.Where(r => r.CategoryText.Contains(IncomeCategoryName)).ToList();
-            var transferRows = rows.Where(r => r.CategoryText.Contains(TransferCategoryName)).ToList();
+            // Separera kategorier: inkomst/förflyttning ska matcha exakt (trim),
+            // annars klassas t.ex. "värnamoresor+övriga" felaktigt som inkomst.
+            var incomeRows = rows
+                .Where(r => string.Equals(
+                    r.CategoryText?.Trim(),
+                    IncomeCategoryName,
+                    StringComparison.Ordinal))
+                .ToList();
+            var transferRows = rows
+                .Where(r => string.Equals(
+                    r.CategoryText?.Trim(),
+                    TransferCategoryName,
+                    StringComparison.Ordinal))
+                .ToList();
             var expenseRows = rows
-                .Where(r => !r.CategoryText.Contains(IncomeCategoryName) && 
-                           !r.CategoryText.Contains(TransferCategoryName))
+                .Where(r =>
+                    !string.Equals(
+                        r.CategoryText?.Trim(),
+                        IncomeCategoryName,
+                        StringComparison.Ordinal)
+                    && !string.Equals(
+                        r.CategoryText?.Trim(),
+                        TransferCategoryName,
+                        StringComparison.Ordinal))
                 .OrderBy(r => r.CategoryText)
                 .ToList();
 

--- a/WebBankBudgeterService/TransFilterer.cs
+++ b/WebBankBudgeterService/TransFilterer.cs
@@ -28,6 +28,13 @@ namespace WebBankBudgeterService
                   && t.DateAsDate <= endDate
                 ).ToList();
 
+            if (fromDate.HasValue && endDate.HasValue
+                && fromDate.Value.Year == endDate.Value.Year)
+            {
+                var y = fromDate.Value.Year;
+                trans = trans.Where(t => t.DateAsDate.Year == y).ToList();
+            }
+
             var filteredTrans = new TransactionList
             {
                 Transactions = trans

--- a/WebBankBudgeterUi/WebBankBudgeter.cs
+++ b/WebBankBudgeterUi/WebBankBudgeter.cs
@@ -129,58 +129,11 @@ namespace WebBankBudgeterUi
         internal static List<Rad> SnurraIgenom(
             IEnumerable<Rad> inData,
             List<BudgetRow> utgifter,
-            Action<string> writeLineToOutputAndScrollDown)
-        {
-            if (utgifter == null)
-            {
-                throw new ArgumentNullException(nameof(utgifter));
-            }
-
-            var kvarrader = new List<Rad>();
-            foreach (var inBudget in inData)
-            {
-                // Synka med kategori och månad.
-                // Hitta motsvarande utgift
-                var motsvarandeUtgifterRader = utgifter
-                    .Where(u => u.CategoryText.Trim() == inBudget.RadNamnY.Trim()
-                    );
-
-                var nuvarandeRad = new Rad { RadNamnY = inBudget.RadNamnY };
-                foreach (var motsvarandeUtgiftsRad in motsvarandeUtgifterRader)
-                {
-                    foreach (var utgiftsMånad in motsvarandeUtgiftsRad.AmountsForMonth)
-                    {
-                        if (inBudget.Kolumner.ContainsKey(utgiftsMånad.Key))
-                        {
-                            // och räkna ut diff.
-                            var kvar =
-                                // inkomst - utgift
-                                inBudget.Kolumner[utgiftsMånad.Key]
-                                + utgiftsMånad.Value; // Utgifter är negativa ie -1200
-
-                            if (!nuvarandeRad.Kolumner.ContainsKey(utgiftsMånad.Key))
-                            {
-                                nuvarandeRad.Kolumner.Add(utgiftsMånad.Key, 0);
-                            }
-
-                            nuvarandeRad.Kolumner[utgiftsMånad.Key] += kvar;
-                        }
-                        else
-                        {
-                            // Fel
-                            var message = "Hittar ingen motsvarande inpost för utgift i :"
-                                          + utgiftsMånad.Key + " och kategori: " + inBudget.RadNamnY;
-
-                            writeLineToOutputAndScrollDown(message);
-                        }
-                    }
-                }
-
-                kvarrader.Add(nuvarandeRad);
-            }
-
-            return kvarrader;
-        }
+            Action<string> writeLineToOutputAndScrollDown) =>
+            InBudgetKvarCalculator.SnurraIgenom(
+                inData,
+                utgifter,
+                writeLineToOutputAndScrollDown);
 
         internal MonthAvarages CalculateMonthlyAvarages()
         {

--- a/plan.md
+++ b/plan.md
@@ -23,7 +23,7 @@ alternativ direkt i denna fil innan extraktorn körs igen.
 | D3 | **`expected-kvar` när IN saknas** för en (kat, månad) (UT-only) | (a) `BudgetAmount = 0`, raden inkluderas · (b) Hoppa raden helt · (c) Inkludera men markera `BudgetAmount = null` | (a) | _____ |
 | D4 | **`expected-kvar` när UT saknas** (IN-only, ingen spend) | (a) `ActualAmount = 0`, `Remaining = BudgetAmount` · (b) Hoppa raden | (a) | _____ |
 | D5 | **Januari 2014 i IN-sektionen** (faktiskt saknas i Excel: 0 rader) | (a) Behåll som tomt — dokumentera som invariant · (b) Generera januari-rader med `BudgetAmount = 0` · (c) Kopiera februari som proxy | (a) — dokumentera; spegla Excel | _____ |
-| D6 | **`TransactionHandler` (saknas fysiskt)** | (a) Leta i git-historik och återställ · (b) Skriv om från grunden mot facit-data · (c) Ersätt med ny tunn klass som läser direkt från facit i tester och från `.xls` i prod | (a) först; (b) som plan B | _____ |
+| D6 | **`TransactionHandler`** | (a) Leta i git-historik och återställ · (b) Skriv om från grunden mot facit-data · (c) Ersätt med ny tunn klass som läser direkt från facit i tester och från `.xls` i prod | (a) först; (b) som plan B | **(a) klar** — klassen finns i `WebBankBudgeterService/TransactionHandler.cs` och används från `WebBankBudgeter` |
 | D7 | **Group-prefix-normalisering** så `"el"` matchar `"Fast el"` | (a) Ändra `Categories.ToString()` att returnera enbart `Name` om `Group` är tom · (b) Använd befintlig `CategoryNameNoGroup` i `TableGetter.GroupOnMonthAndCategory` · (c) Skapa ny `CategoryNameNormalized` | (b) — `CategoryNameNoGroup` finns redan, minst risk | _____ |
 | D8 | **Sparrader** (`spara almänt`, `spara till amortering`) | (a) Behandla som utgifter (default i koden idag) · (b) Egen sektion "sparande" i UI och facit | (a) | _____ |
 | D9 | **`BudgetIns.json`-format** för 2014/2015 i prod-koden | (a) Behåll befintligt schema (`CategoryDescription`/`BudgetValue`/`YearAndMonth`) — generera dem från facit · (b) Migrera prod-koden till samma format som `budget-in-YYYY.json` | (a) — minst kodändring i InbudgetHandler | _____ |
@@ -108,8 +108,8 @@ Kategorierna inkluderar `hyra (inkl. 1k amortering)`, `si och akassa`,
 ### 2.1 Nuvarande dataflöde
 
 ```
-Excel (`Pelles Budget.xls`)
-  └─► TransactionHandler  (saknas fysiskt i repo; refererad)
+Excel (`pelles budget.xls` i repo-roten eller sökväg via GeneralSettings)
+  └─► TransactionHandler (`WebBankBudgeterService/TransactionHandler.cs`)
         └─► Transaction { DateAsDate, Description, AmountAsDouble,
                           Categorizations.Categories[0].{Group, Name} }
               └─► CategoryName = "Group Name"  (← sammanslagning!)
@@ -123,24 +123,26 @@ Excel (`Pelles Budget.xls`)
 `InBudget`-sidan:
 
 ```
-TestData/BudgetIns.json
+TestData/BudgetIns.json (kopia under ConsoleBudgeter för textfacit)
   └─► List<InBudget> { CategoryDescription, BudgetValue, YearAndMonth }
         └─► InBudgetHandler → List<Rad> { RadNamnY, Kolumner["2014 January"] = ... }
-              └─► WebBankBudgeter.SnurraIgenom(inBudget, utgifter)
+              └─► InBudgetKvarCalculator.SnurraIgenom (samma som WebBankBudgeter.SnurraIgenom)
                     └─► kvar = inBudget.Kolumner[key] + utgiftsMånad.Value
-                          └─► gv_Kvar  (⚠ INTE aktiv just nu — se 2.3)
+                          └─► gv_Kvar: i `FillTablesAsync` används idag `BindKvarBudgetTableUi` (samma tabell som Budget Total); `VisaKvarRader_…` med SnurraIgenom finns men anropas inte här.
 ```
+
+**Textfacit (konsol):** `ConsoleBudgeter`-projektet skriver samma typ av utdata till fil (`--out`). Se `AGENTS.md` och `README.md`.
 
 ### 2.2 Viktiga detaljer i nuvarande kod
 
 - **Månadsnyckel**: `Transaction.GetYearMonthName` ger `"YYYY MMMM"` på invariant­kultur (t.ex. `"2014 January"`).
 - **Kategori­nyckel**: `Transaction.CategoryName` = `$"{Group} {Name}"` — dvs grupp-prefix. `BudgetRow.CategoryText` är samma sträng.
 - **Klassificering** i `BudgetStructureBuilder`:
-  - Inkomst: `CategoryText.Contains("+")`
-  - Förflyttning: `CategoryText.Contains(" -")` (mellanslag före minus)
-  - Utgift: övrigt
-- **Budget Total-fliken** (`gv_budget`) visar IN + UT + summerings­rader.
-- **Kvar-fliken** (`gv_Kvar`) visade samma som Budget Total efter tidigare refactor. (`VisaKvarRader_BindInPosterRaderTillUiAsync` finns men anropas inte längre; den beräknar riktigt kvar via `SnurraIgenom`.)
+  - Inkomst: trimmat kategorinamn **lika med** `"+"` (inte `Contains`, så t.ex. `värnamoresor+övriga` blir utgift).
+  - Förflyttning: trimmat **lika med** `" -"` (ett mellanslag före minus).
+  - Utgift: övrigt.
+- **Budget Total-fliken** (`gv_budget`) visar transaktionsbaserad tabell + summerings­rader (struktur från `BudgetStructureBuilder`).
+- **Kvar-fliken** (`gv_Kvar`): i `WebBankBudgeterUi.FillTablesAsync` anropas `BindKvarBudgetTableUi(table)` — samma `TextToTableOutPuter` som Budget Total. För **IN+UT-kvar** via `SnurraIgenom` finns `VisaKvarRader_BindInPosterRaderTillUiAsync` men den är inte inkopplad i denna kodväg.
 
 ### 2.3 Gap mellan facit och nuvarande kod
 
@@ -152,7 +154,7 @@ TestData/BudgetIns.json
 | G4 | Tecken-konvention | IN ≥ 0, UT ≤ 0, KVAR = IN + UT | Samma i `SnurraIgenom` | OK |
 | G5 | Auto-kategorisering | `CategoryHandler` matchar hela `InfoDescription` exakt | Case-insensitive trim-jämförelse på hela beskrivningen | Facit visar många fria­texter (`PILEG$RDENS SERVICEBUT ASKIM`) → kräver substring/regex-matchning eller manuellt angivna aliaser |
 | G6 | BudgetIns.json täckning | 363 in-rader / år × 2 år = 726 rader | Testdata har 10 rader för år 2016 | Måste fyllas med riktig budget för 2014/2015 (kan genereras direkt ur facit-filen) |
-| G7 | Filkälla | Flera transaktioner per dag, sve-kultur­decimaler | Läser `.xls` via `TransactionHandler` (klassen **saknas fysiskt** — se M0 nedan) | Kontrollera att läsningen levererar exakt samma 1 654 rader |
+| G7 | Filkälla | Flera transaktioner per dag, sve-kultur­decimaler | Läser `.xls` via `TransactionHandler` | Verifiera mot Excel (~1 654 rader 2014+2015); `TransFilterer` filtrerar även på `DateAsDate.Year` när helår väljs (plan R5) |
 | G8 | Regulatorflagga | `Regular` / `Ignore` i kol 12 | Oklart om den filtreras | Beslut **D12**: `Ignore`-rader inkluderas i facit men exkluderas i `expected-ut` så filterregeln blir testbar |
 | G9 | Månadskultur | `"YYYY January"` (engelska) | `Transaction.GetMonthAsFullString` — kultur ej verifierad i koden | Beslut **D10**: Verifiera att `MMMM`-formatteringen är invariant; om inte, ändra i M5 |
 
@@ -390,20 +392,13 @@ Fil: `WebBankBudgeterUiTest/BudgetIntegrationTests.cs` (ny)
 
 ## 5. Implementations­plan — 6 milstolpar
 
-### M0 — Återställ eller ersätt `TransactionHandler` (förkrav för M5)
+### M0 — `TransactionHandler` och produktionsväg
 
-`WebBankBudgeter.cs:18` refererar `TransactionHandler` men ingen `class TransactionHandler`
-finns i kodbasen (verifierat med Grep). Beslut **D6** styr vägen:
+**Status i repo:** `TransactionHandler` finns i `WebBankBudgeterService/TransactionHandler.cs` och används från `WebBankBudgeter`.
 
-- **D6 = a** (default): Sök i git-historiken (`git log --all --diff-filter=D -- '**/TransactionHandler.cs'`)
-  och återställ. Verifiera att den fortfarande kompilerar och att `TransactionList.Account.AvailableAmount`
-  + `TransactionList.Transactions` exponeras som `WebBankBudgeter.cs:222` förväntar.
-- **D6 = b**: Skriv om mot facit-data först, sedan generalisera till `.xls` när M3 är grön.
-- **D6 = c**: Inför ett `ITransactionSource`-interface; två impl: `FacitTransactionSource` (för
-  tester) och `XlsTransactionSource` (för prod). `WebBankBudgeter` får interfacet via constructor.
+Kvar för **M0** är i praktiken **verifiering mot riktig miljö**: att `pelles budget.xls` (eller motsvarande) laddas, att antal rader stämmer med Excel (~1 654 för 2014+2015), och att `TransactionList` / saldo beter sig som UI förväntar — inte att återställa en saknad klass.
 
-Denna milstolpe blockerar inte M1–M4 (facit + tester körs utan att ladda riktiga `.xls`).
-Måste vara klar innan M5.
+Beslut **D6** (a/b/c) gäller om klassen behöver skrivas om i framtiden; default **(a)** är uppfylld i nuvarande kodbas.
 
 ### M1 — Skapa facit-mappen och extraktor-verktyget
 
@@ -503,12 +498,12 @@ Förkrav: M0 är klar.
 
 | # | Risk | Mitigering |
 |---|------|------------|
-| R1 | `TransactionHandler.cs` finns inte fysiskt i arbetskopian (men refereras från `WebBankBudgeter.cs:18, 28, 58, 69, 72`) | M0 (ny milstolpe) hanterar detta enligt D6 — måste vara löst innan M5 |
+| R1 | ~~`TransactionHandler` saknas~~ (inaktuellt) | Klassen finns under `WebBankBudgeterService/`; se M0 för verifiering mot riktig `.xls` |
 | R2 | UT/KVAR är `#VALUE!` i Excel-filen | Accepteras — vi räknar dem själva ur transaktionerna; det är ju precis det appen ska göra |
 | R3 | Kategori­namn i Excel har specialtecken (`ö`, `å`, `£`) | JSON/UTF-8 hanterar det; kontrollera att `.csproj` använder `utf-8` BOM eller explicit encoding |
 | R4 | Svensk kultur i Excel vs invariant i koden | Extraktorn använder `sv-SE` på Excel-sidan, skriver punkt-decimaler i JSON; koden använder invariant → match OK |
-| R5 | Transaktioner för 2013-december finns i filen (Allkortsfaktura) | Filtrera strikt på `Year == 2014` resp `Year == 2015` |
-| R6 | Pågående ändring: `gv_Kvar` visar just nu Budget Total-data (TODO.md-arbetet utfört, se `WebBankBudgeterUi.cs:230-233`) | M5.2 avgör om tillståndet behålls eller om riktig Kvar-vy återinförs |
+| R5 | Transaktioner för granår kan ligga i samma fil | `TransFilterer`: vid filter på ett kalenderår krävs även `DateAsDate.Year == valt år` |
+| R6 | `gv_Kvar` duplicerar Budget Total-tabellen | Bekräftat i `FillTablesAsync` via `BindKvarBudgetTableUi`. För IN+UT-kvar: koppla in `VisaKvarRader_BindInPosterRaderTillUiAsync` med utgiftsrader från samma struktur som Budget Total (se Slack/plan M5) |
 | R7 | Floating-point-drift vid summering av >100 rader om D1 = c | Beslut D1 (default a) hanterar detta med olika toleranser för cell vs aggregat |
 | R8 | Sorteringsskillnad: kod sorterar `OrderByDescending(CategoryText)` (`TableGetter.cs:39`), facit sorterar stigande | Beslut D14 (default b): jämför som dictionary i tester |
 
@@ -522,7 +517,7 @@ Förkrav: M0 är klar.
 3. **M3** (service­tester) — validerar tran­saktions­aggregering och Kvar-matte.
 4. **Commit** — allt ovan kan committas utan att ändra produktions­kod.
 5. **M4** (UI-tester som failar) — dokumenterar exakt vilka gap som finns.
-6. **M0** (`TransactionHandler` återställs/skrivs om) — kan göras parallellt med M3/M4.
+6. **M0** (verifiering av `TransactionHandler` + `.xls` i prod) — kan göras parallellt med M3/M4.
 7. **M5** (driv in koden) — en punkt i taget tills alla tester grönar.
 
 Varje milstolpe ska vara committable på egen hand och ha alla tester gröna.

--- a/todo.md
+++ b/todo.md
@@ -1,97 +1,23 @@
-# TODO: Visa samma data på "Kvar"-fliken som "Budget Total"
+# TODO (levande lista)
 
-## Problem
+Uppdatera denna fil när något **byggts, testats och verifierats** (samma rutin som `AGENTS.md` / `README.md`).
 
-"Kvar"-fliken (`gv_Kvar`) är nästan tom medan "Budget Total" (`gv_budget`) visar full
-budgetdata med alla kategorier, medelvärden och månadskolumner.
+## Klart i kod (denna arbetskopia)
 
-**Orsak:** "Kvar" använder en helt annan databindnings-kedja (`InBudgetUiHandler.BindInPosterRaderTillUi`)
-som förlitar sig på InBudget-data från `BudgetIns.json`, medan "Budget Total" använder
-`UtgiftsHanterareUiBinder.BindToBudgetTableUi` som bygger på transaktionsdata.
+- **`TransactionHandler`:** finns i `WebBankBudgeterService/TransactionHandler.cs` (planens gamla “saknas” är inaktuellt — se `plan.md` D6/M0).
+- **`BudgetStructureBuilder`:** inkomst/förflyttning klassas med **exakt** trimmat `"+"` resp. `" -"`.
+- **`TransFilterer`:** vid filter på ett helt kalenderår krävs `DateAsDate.Year == valt år` (plan R5).
+- **`ConsoleBudgeter`:** konsolprojekt som kan skriva textfacit med `--out` (se `README.md`).
+- **`InBudgetKvarCalculator.SnurraIgenom`:** delad implementation i `InbudgetHandler` (används från `WebBankBudgeter.SnurraIgenom`).
 
-## Plan — 4 steg
+## Öppet / nästa
 
-### Steg 1: Gör `UtgiftsHanterareUiBinder.BindToBudgetTableUi` generisk
+- **`gv_Kvar` i WinForms:** `FillTablesAsync` använder `BindKvarBudgetTableUi` (samma data som Budget Total). Koppla in `VisaKvarRader_BindInPosterRaderTillUiAsync` om fliken ska visa **IN+UT-kvar** enligt `SnurraIgenom`.
+- **Facit JSON + extraktor:** enligt `plan.md` M1–M3 (filer under t.ex. shared test-projekt) — **inte** implementerat i denna clone utöver Excel i roten + plan.
+- **Textfacit-fil:** generera med `ConsoleBudgeter` och committa när innehållet är granskat (`Facit/facit-2014-2015-console.txt` eller enad sökväg).
 
-**Fil:** `WebBankBudgeterUi/UiBinders/UtgiftsHanterareUiBinder.cs`
+---
 
-Lägg till en `DataGridView`-parameter så metoden kan binda till vilken grid som helst:
+## Arkiv: gammal fyra-stegs-plan (Kvar = kopia av Budget Total)
 
-```csharp
-// Från:
-public void BindToBudgetTableUi(TextToTableOutPuter table)
-{
-    var grid = _gv_budget;
-
-// Till:
-public void BindToBudgetTableUi(TextToTableOutPuter table, DataGridView targetGrid = null)
-{
-    var grid = targetGrid ?? _gv_budget;
-```
-
-Byt alla `_gv_budget`-referenser i metoden till `grid`.
-
-### Steg 2: Anropa bind-metoden för `gv_Kvar`
-
-**Fil:** `WebBankBudgeterUi/WebBankBudgeterUi.cs`
-
-I `FillTablesAsync()`, efter `BindToBudgetTableUi(table)` (rad ~78), lägg till:
-
-```csharp
-BindToBudgetTableUi(table);       // befintligt (gv_budget)
-BindKvarBudgetTableUi(table);     // NYTT (gv_Kvar)
-```
-
-Ny wrapper-metod:
-
-```csharp
-private void BindKvarBudgetTableUi(TextToTableOutPuter table)
-{
-    _utgiftsHanterareUiBinder.BindToBudgetTableUi(table, gv_Kvar);
-}
-```
-
-### Steg 3: Ta bort gammal Kvar-kolumninitiering
-
-**Fil:** `WebBankBudgeterUi/WebBankBudgeterUi.cs`
-
-I `InitIncomesUi()` (rad ~190), ta bort raden:
-
-```csharp
-gv_Kvar.Columns.Add("1", WebBankBudgeter.CategoryNameColumnDescription);
-```
-
-Kolumnerna skapas nu istället av `UtgiftsHanterareUiBinder`.
-
-### Steg 4: Ersätt gammal Kvar-bindning med den nya
-
-**Fil:** `WebBankBudgeterUi/WebBankBudgeterUi.cs`
-
-I `FillTablesAsync()`, ersätt anropet (rad ~91-92):
-
-```csharp
-// FRÅN (gammal — ger nästan tom tabell):
-await VisaKvarRader_BindInPosterRaderTillUiAsync(utgiftsRader);
-
-// TILL (ny — samma data som Budget Total):
-BindKvarBudgetTableUi(table);
-```
-
-**OBS:** "Budget Total"-fliken (`gv_budget`) ändras INTE. Den förblir exakt som idag.
-Bara "Kvar"-fliken (`gv_Kvar`) får ny data — genom att använda samma
-bindningslogik som redan fungerar för Budget Total.
-
-## Förväntat resultat
-
-- **Budget Total** — helt oförändrad
-- **Kvar** — visar nu samma kolumner som Budget Total:
-  `Category . Month->`, `Average`, `Average-nf`, månadskolumner, `Summa`
-- Samma rader med samma gruppering (utgifter, summa utgifter, inkomster, förflyttningar, budgettotal)
-- Samma formatering (fetstil och grå bakgrund på summeringsrader)
-
-## Filer som ändras
-
-| Fil | Ändring |
-|-----|---------|
-| `WebBankBudgeterUi/UiBinders/UtgiftsHanterareUiBinder.cs` | Ny parameter `DataGridView targetGrid` |
-| `WebBankBudgeterUi/WebBankBudgeterUi.cs` | Ny `BindKvarBudgetTableUi`, anrop i `FillTablesAsync`, bort med gammal kvar-logik och init |
+Den gamla `todo.md` beskrev medvetet att låta `gv_Kvar` använda samma bindning som `gv_budget`. Det är fortfarande så i `WebBankBudgeterUi.FillTablesAsync` (`BindKvarBudgetTableUi`). Om målet ändras till **SnurraIgenom**-Kvar, ersätts det av punkten “Öppet” ovan — inte av den arkiverade listan.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Syfte

Inför versionskontrollerade agentinstruktioner, spårbar historik, ett körningsbart konsolprojekt för textfacit samt synka plan/todo/README med faktisk kod i denna arbetskopia.

## Ändringar

- **`AGENTS.md`:** Regler för facit (kör `ConsoleBudgeter`, spara `--out`), branch-verifiering innan påståenden, ingen parallell Python-pipeline, uppdatering av plan/todo/README/HISTORY efter verifierad ändring.
- **`HISTORY.md`:** Dokumenterar bl.a. att denna clone stod på `master` före grenen; notis om att incheckad `pelles budget.xls` gav 0 rader för 2014/2015 vid testkörning här.
- **`ConsoleBudgeter`:** Nytt `net8.0`-projekt i lösningen; diagnostikblock + `--transaction-file`; kopierad `GeneralSettings.xml` och `BudgetIns.json` under projektet.
- **`InBudgetKvarCalculator`:** `SnurraIgenom` flyttad till `InbudgetHandler`; `WebBankBudgeter` delegerar.
- **`BudgetStructureBuilder`:** Inkomst/förflyttning matchas med trimmat exakt `"+"` / `" -"`.
- **`TransFilterer`:** Vid filter där `from` och `to` är samma kalenderår krävs `DateAsDate.Year == det året` (plan R5).
- **`plan.md` / `todo.md` / `README.md`:** `TransactionHandler` finns; Kvar-flikens faktiska bindning dokumenterad; kommando för textfacit; länk till AGENTS/HISTORY.
- **`Facit/README.md`:** Hur man genererar textfacit och att diagnostik ska kontrolleras.

## Verifiering

- `dotnet build ConsoleBudgeter/ConsoleBudgeter.csproj` — lyckades.
- `dotnet test` för befintliga testprojekt misslyckas i denna clone p.g.a. befintliga teckenkodningsfel i vissa testfiler (före denna PR); inga av dessa filer ändrades här.

## Notis om textfacit 2014–2015

Den incheckade `pelles budget.xls` gav vid körning här **noll** transaktioner för 2014 och 2015; använd `--transaction-file` mot full export och kontrollera diagnostikraderna innan committad facit-fil.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://pellesbits.slack.com/archives/D0AUWLPQRU5/p1777037210978829?thread_ts=1777037210.978829&cid=D0AUWLPQRU5)

<div><a href="https://cursor.com/agents/bc-0f74b445-ddb6-5b5c-b729-b040403ed200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f74b445-ddb6-5b5c-b729-b040403ed200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

