### PR TITLE
ConsoleBudgeter: självmantlad Linux-publicering (ingen .NET på målmaskinen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Självmantlad publicering av ConsoleBudgeter (byggs lokalt/CI, checkas inte in)
+/artifacts/
+
 Release
 Debug
 

--- a/ConsoleBudgeter/Properties/PublishProfiles/Linux-x64-SelfContained.pubxml
+++ b/ConsoleBudgeter/Properties/PublishProfiles/Linux-x64-SelfContained.pubxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Självmantlad Linux-x64-publicering: ingen .NET SDK eller runtime krävs på målmaskinen.
+  Bygg från repo-rot: dotnet publish ConsoleBudgeter/ConsoleBudgeter.csproj -c Release -p:PublishProfile=Linux-x64-SelfContained
+  Kör: ./artifacts/ConsoleBudgeter/linux-x64/ConsoleBudgeter --help
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <!-- Relativt ConsoleBudgeter/ (projektmapp) → repo-rot/artifacts/... -->
+    <PublishDir>../artifacts/ConsoleBudgeter/linux-x64/</PublishDir>
+  </PropertyGroup>
+</Project>

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,12 @@
 > `HISTORY_ARCHIVE.md` och denna fil rensas för att endast innehålla senaste arbetets historik.
 > Detta håller filen lättläst och relevant medan fullständig historik bevaras i arkivet.
 
+## 2026-04-26 — ConsoleBudgeter: självmantlad Linux-publicering
+
+**Vad:** `PublishProfiles/Linux-x64-SelfContained.pubxml` + `scripts/publish-console-budgeter-linux.sh`; utdata till `artifacts/ConsoleBudgeter/linux-x64/`. **Varför:** köra `ConsoleBudgeter` på Linux utan installerad .NET SDK/runtime på målmaskinen (runtime följer med vid publicering). **`/artifacts/`** tillagd i `.gitignore`. **Git:** branch `cursor/console-budgeter-self-contained-8460` (molnmiljöns PR-krav); användaren önskade arbetsbas `master`.
+
+---
+
 ## 2026-04-26 — `master` synkad med `origin/cursor/console-budgeter-app-1a34`
 
 **Git-fakta (denna klon, innan merge):** `master` låg på `5e1c121` (Excel + plan/README). `origin/cursor/console-budgeter-app-1a34` hade **29 commits** ovanför gemensam ancestor `90a5331` och bar därmed `ConsoleBudgeter`, `WebBankBudgeterTests.Facit`, `InbudgetHandler`-delar (Kvar/IN-merge), m.m. Det förklarar “gren på gren” i `git log --graph`: en lång serie `cursor/`-commits på samma funktionella kedja, medan `master` hade en avstickare (`5e1c121`) som inte fanns på console-grenen. **Åtgärd:** merge av `origin/cursor/console-budgeter-app-1a34` in i `master` (ingen ny `cursor/…`-gren för just denna leverans).

--- a/README.md
+++ b/README.md
@@ -151,3 +151,35 @@ dotnet run --project ConsoleBudgeter/ConsoleBudgeter.csproj -- \
 ```
 
 Tester: `dotnet test ConsoleBudgeterTest/ConsoleBudgeterTest.csproj`
+
+### ConsoleBudgeter utan .NET på målmaskinen (Linux x64)
+
+Med **självmantlad** publicering följer .NET-runtime med i utdata. På en annan Linux (t.ex. din laptop) behöver du då **inte** installera SDK eller runtime — bara kopiera publiceringsmappen och köra binären.
+
+Bygg (kräver .NET SDK **på byggmaskinen**, t.ex. CI eller din dev-dator):
+
+```bash
+./scripts/publish-console-budgeter-linux.sh
+```
+
+Alternativt utan skript:
+
+```bash
+dotnet publish ConsoleBudgeter/ConsoleBudgeter.csproj -c Release -p:PublishProfile=Linux-x64-SelfContained
+```
+
+Utdata hamnar under **`artifacts/ConsoleBudgeter/linux-x64/`** (mappen är ignorerad av git). Kör t.ex.:
+
+```bash
+./artifacts/ConsoleBudgeter/linux-x64/ConsoleBudgeter --help
+```
+
+För textfacit (samma som i `AGENTS.md`):
+
+```bash
+./artifacts/ConsoleBudgeter/linux-x64/ConsoleBudgeter -- \
+  --year 2014 --year 2015 --transactions 0 \
+  --out WebBankBudgeterTests.Facit/Facit/facit-2014-2015.txt
+```
+
+För Windows eller andra RID:er kan du lägga en egen `PublishProfiles/*.pubxml` med annat `RuntimeIdentifier` (t.ex. `win-x64`).

--- a/plan.md
+++ b/plan.md
@@ -11,7 +11,7 @@ Målet är att UI:t ska visa exakt samma struktur och data som Excel-förlagan:
 
 ## Rutin för agenter och dokumentation
 
-Se **`AGENTS.md`** i repo-roten: textfacit (`facit-2014-2015.txt`) skapas endast via `ConsoleBudgeter --out`; facit ändras inte bara för att “få grönt”; efter verifierad build uppdateras denna plan, `todo.md`, `README.md` och `HISTORY.md` vid behov.
+Se **`AGENTS.md`** i repo-roten: textfacit (`facit-2014-2015.txt`) skapas endast via `ConsoleBudgeter --out`; facit ändras inte bara för att “få grönt”; efter verifierad build uppdateras denna plan, `todo.md`, `README.md` och `HISTORY.md` vid behov. För att **köra** `ConsoleBudgeter` på Linux utan installerad .NET-runtime på målmaskinen: självmantlad publicering (`Linux-x64-SelfContained.pubxml`, skript under `scripts/`) — se `README.md`.
 
 ---
 

--- a/scripts/publish-console-budgeter-linux.sh
+++ b/scripts/publish-console-budgeter-linux.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Publicerar ConsoleBudgeter som självmantlad linux-x64 (ingen .NET-installation på målmaskinen).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+dotnet publish ConsoleBudgeter/ConsoleBudgeter.csproj \
+  -c Release \
+  -p:PublishProfile=Linux-x64-SelfContained
+echo "Körbar fil: $ROOT/artifacts/ConsoleBudgeter/linux-x64/ConsoleBudgeter"

--- a/todo.md
+++ b/todo.md
@@ -16,9 +16,10 @@
 2. [x] Lägga `AGENTS.md` i repo-roten.
 3. [x] Skapa/uppdatera `HISTORY.md` (branchläge, merge, förklaring av TransactionHandler vs gammal plan-text).
 4. [ ] Kör `dotnet build` / `dotnet test` (lämpliga projekt) lokalt eller i CI — markera när grönt. *(Cloud Agent-miljön här saknade `dotnet` i PATH vid senaste körning — kör samma kommandon på din maskin.)*
-5. [x] Uppdatera `plan.md` (textfacit-filnamn `facit-2014-2015.txt`; övrig plan fanns redan uppdaterad efter merge).
-6. [x] Uppdatera `README.md` (`AGENTS.md`, textfacit, regenerate-kommando).
-7. [x] Committa merge + dokumentation på `master` och pusha `master`.
+5. [ ] Verifiera `./scripts/publish-console-budgeter-linux.sh` och kör `./artifacts/ConsoleBudgeter/linux-x64/ConsoleBudgeter --help` på en maskin med SDK (publicerad binär ska fungera utan .NET på en ren Linux-målmaskin).
+6. [x] Uppdatera `plan.md` (textfacit-filnamn `facit-2014-2015.txt`; övrig plan fanns redan uppdaterad efter merge).
+7. [x] Uppdatera `README.md` (`AGENTS.md`, textfacit, regenerate-kommando).
+8. [x] Committa merge + dokumentation på `master` och pusha `master`.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Syfte

Göra det möjligt att **köra `ConsoleBudgeter` på Linux x64** på en maskin **utan** installerad .NET SDK eller runtime, genom **självmantlad** publicering (runtime följer med).

## Ändringar

- **`ConsoleBudgeter/Properties/PublishProfiles/Linux-x64-SelfContained.pubxml`** — `linux-x64`, `SelfContained`, single file med komprimering; utdata till `artifacts/ConsoleBudgeter/linux-x64/`.
- **`scripts/publish-console-budgeter-linux.sh`** — kör `dotnet publish` med profilen.
- **`.gitignore`** — `/artifacts/` (byggartefakter checkas inte in).
- **`README.md`** — avsnitt med bygg- och körinstruktioner samt facit-exempel med publicerad binär.
- **`plan.md`**, **`todo.md`**, **`HISTORY.md`** — kort hänvisning / historikpost enligt `AGENTS.md`.

## Verifiering

Molnmiljön hade **ingen `dotnet` i PATH**; merge efter lokal körning av `./scripts/publish-console-budgeter-linux.sh` och ev. `dotnet test` rekommenderas.

## Notering om gren

Användaren önskade bas `master`; ändringarna ligger på `cursor/console-budgeter-self-contained-8460` enligt Cloud Agent-krav.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://pellesbits.slack.com/archives/D0AUWLPQRU5/p1777190046649039?thread_ts=1777190046.649039&cid=D0AUWLPQRU5)

<div><a href="https://cursor.com/agents/bc-38174b59-8b87-50a2-bd46-9703cae38460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38174b59-8b87-50a2-bd46-9703cae38460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

