### PR TITLE
test(M0): facit-transaktionsantal i WebBankBudgeterServiceTest

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,11 @@
 > **Syfte:** Dokumentera **vad som spelar roll idag** (beslut, buggar, verktyg, Linux) och korta **sessionsfakta**.  
 > **Underhåll:** Lägg nya upptäckter under *Del A*. Långa bakgrundsposter ligger i **`HISTORY_ARCHIVE.md`**.
 
-## 2026-04-28 — Tester: snapshots + `Check_If_SomeThingLoaded_Privata`
+## 2026-04-28 — Tester (snapshots, Swedbank-test) och M0 facit-räkning
 
-**Syfte:** `dotnet test Budgetterarn.NoWindowsUi.slnf` grönt. Uppdaterade `ConsoleBudgeterTest/Snapshots/report-2014.txt` och `report-2015.txt` till aktuell rapport (radordning `" -"` i budgettabell, borttagen förflyttnings-summeringsblock). `SnapshotTests.Normalize` strippar UTF-8 BOM. `GetAllVisibleEntriesFromWebBrowserTests.Check_If_SomeThingLoaded_Privata` sökte med `DateTime.Today.ToShortDateString()` som nyckel — stämmer inte med `KontoEntry.KeyForThis` (`yyyy-MM-dd`); bytt till uppslag via `Info`.
+**Snapshots / UI-test:** `dotnet test Budgetterarn.NoWindowsUi.slnf` grönt efter uppdaterade `ConsoleBudgeterTest/Snapshots/report-2014.txt` och `report-2015.txt`, samt `SnapshotTests.Normalize` som strippar UTF-8 BOM. `Check_If_SomeThingLoaded_Privata` fixad (nyckel via `Info`, inte `DateTime.Today`).
+
+**M0 (del):** `WebBankBudgeterServiceTest/FacitTransactionCountTests.cs` — 809 + 845 transaktioner i facit-JSON enligt `WebBankBudgeterTests.Facit/Facit/README.md`. Full `TransactionHandler` + `.xls` kvar manuellt där filen finns.
 
 ---
 

--- a/WebBankBudgeterServiceTest/FacitTransactionCountTests.cs
+++ b/WebBankBudgeterServiceTest/FacitTransactionCountTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebBankBudgeterTests.Facit;
+
+namespace WebBankBudgeterServiceTest;
+
+/// <summary>
+/// M0 (del): antal transaktioner i fryst facit-JSON ska stämma med
+/// <c>WebBankBudgeterTests.Facit/Facit/README.md</c> (samma underlag som Excel-källan).
+/// Full inläsning via <c>TransactionHandler</c> från <c>.xls</c> kräver lokal fil — se <c>plan.md</c>.
+/// </summary>
+[TestClass]
+public class FacitTransactionCountTests
+{
+    [TestMethod]
+    public void FacitJson_2014_Has809Transactions()
+    {
+        Assert.HasCount(809, FacitLoader.LoadTransactions(2014));
+    }
+
+    [TestMethod]
+    public void FacitJson_2015_Has845Transactions()
+    {
+        Assert.HasCount(845, FacitLoader.LoadTransactions(2015));
+    }
+
+    [TestMethod]
+    public void FacitJson_Combined2014And2015_Has1654Transactions()
+    {
+        var n2014 = FacitLoader.LoadTransactions(2014).Count;
+        var n2015 = FacitLoader.LoadTransactions(2015).Count;
+        Assert.AreEqual(1654, n2014 + n2015, "809 + 845 enligt facit-README");
+    }
+}

--- a/plan.md
+++ b/plan.md
@@ -12,9 +12,10 @@ Målbild: UI ska matcha struktur och data mot Excel-facit `Pelles-budget-slim-20
 
 ### M0 — `TransactionHandler` och transaktionsantal
 
-1. Bekräfta att `WebBankBudgeterService/TransactionHandler.cs` exponerar det som `WebBankBudgeterUi/WebBankBudgeter.cs` förväntar (`TransactionList.Transactions`, `TransactionList.Account.AvailableAmount` m.m. — exakta rader: läs koden).
-2. Läs in avsedd källfil (t.ex. `Pelles Budget.xls` / motsvarande) och verifiera **~1 654** transaktioner över 2014+2015 enligt facitunderlag.
-3. Vid `MSB3021`/`MSB3027` under full build: stäng körande WinForms eller bygg med `Budgetterarn.NoWindowsUi.slnf`.
+1. Bekräfta att `WebBankBudgeterService/TransactionHandler.cs` exponerar det som `WebBankBudgeterUi/WebBankBudgeter.cs` förväntar (`TransactionList.Transactions`, `TransactionList.Account` m.m. — läs koden).
+2. **Facit-JSON (CI):** antal transaktioner per år enligt `WebBankBudgeterTests.Facit/Facit/README.md` (2014 = 809, 2015 = 845, summa 1654) täcks av `WebBankBudgeterServiceTest/FacitTransactionCountTests.cs`.
+3. **Riktig `.xls` (manuellt / lokal maskin):** ladda samma källa som facit (`Pelles Budget.xls`) via `TransactionHandler` och jämför volym/struktur med facit-JSON — kräver att filen finns på sökväg i `GeneralSettings.xml` (`TransactionTestFilePath`).
+4. Vid `MSB3021`/`MSB3027` under full build: stäng körande WinForms eller bygg med `Budgetterarn.NoWindowsUi.slnf`.
 
 ---
 

--- a/todo.md
+++ b/todo.md
@@ -4,8 +4,8 @@
 
 | Uppgift | Anteckning |
 |---------|--------------|
-| **Bygg och test** | `dotnet build Budgetterarn.NoWindowsUi.slnf` och `dotnet test Budgetterarn.NoWindowsUi.slnf` (Linux/CI); hela `Budgetterarn.sln` på Windows om WinForms ska med. |
-| **M0** | Verifiera `TransactionHandler` mot avsedd transaktionskälla (~1 654 rader 2014+2015) och att UI-fasaden får rätt `TransactionList` — se `plan.md`. |
+| **Bygg och test** | `dotnet build Budgetterarn.NoWindowsUi.slnf` och `dotnet test Budgetterarn.NoWindowsUi.slnf` (Linux/CI); hela `Budgetterarn.sln` på Windows om WinForms ska med. Kräver `.NET 8 SDK` i `PATH` (t.ex. `dotnet-sdk-8.0` på Ubuntu). |
+| **M0** | **Kvar:** `TransactionHandler` + samma `Pelles Budget.xls` som facit kom från — jämför antal/struktur mot facit-JSON i CI (saknas ofta i sandlådor). **Automatiserat:** antal rader i `transactions-2014/2015.json` (809+845) testas i `WebBankBudgeterServiceTest/FacitTransactionCountTests.cs`. UI ↔ `TransactionList` / `Account`: se `plan.md`. |
 | **M4** | UI-integrationstester (`BudgetIntegrationTests`) — `net8.0-windows`; spec i arkivet §4.3. |
 | **M3 (valfritt)** | Utöka service-tester så de täcker samma intent som tabellen i arkivet §4.2 (filnamn i arkiv: `FacitBudgetTests.cs`). |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Syfte

Fortsättning från `todo.md` **M0**: automatisera den del som går att regressionstesta i CI utan `Pelles Budget.xls`.

## Ändringar

- Ny `WebBankBudgeterServiceTest/FacitTransactionCountTests.cs`: verifierar antal rader i `transactions-2014.json` / `transactions-2015.json` (809, 845, summa 1654) enligt `WebBankBudgeterTests.Facit/Facit/README.md` — samma tal som redan testas i `ConsoleBudgeterTest/FacitAggregationTests`.
- `todo.md` / `plan.md`: tydliggör vad som är automatiserat vs kvar (inläsning via `TransactionHandler` mot riktig `.xls`).
- `HISTORY.md`: kort sessionspost.

## Verifiering

`dotnet build Budgetterarn.NoWindowsUi.slnf` och `dotnet test Budgetterarn.NoWindowsUi.slnf` — grönt (30 service-tester inkl. tre nya).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://pellesbits.slack.com/archives/D0AUWLPQRU5/p1777301360653309?thread_ts=1777301360.653309&cid=D0AUWLPQRU5)

<div><a href="https://cursor.com/agents/bc-9d733737-852d-5200-97e3-31c552284175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d733737-852d-5200-97e3-31c552284175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

